### PR TITLE
Add GiftType attribute to Order Header

### DIFF
--- a/lib/gentle/documents/request/shipment_order.rb
+++ b/lib/gentle/documents/request/shipment_order.rb
@@ -59,7 +59,7 @@ module Gentle
                             'NoteValue': note[:note_value])
                 end
               
-                xml.GiftWrap @gift_wrap
+                xml.GiftType "giftwrapped" if @gift_wrap
 
                 if @shipment.respond_to?(:value_added_services)
                   @shipment.value_added_services.each do |service|

--- a/lib/gentle/documents/request/shipment_order.rb
+++ b/lib/gentle/documents/request/shipment_order.rb
@@ -27,6 +27,7 @@ module Gentle
           @comments = options.fetch(:comments, nil) || @shipment.order.special_instructions
           @notes = options.fetch(:notes)
           @gift = options.fetch(:gift, false)
+          @gift_wrap = options.fetch(:gift_wrap, false)
           @item_filter = options.fetch(:item_filter, nil) || Proc.new { |line_item| true }
           @shipment_number = @shipment.number
         end
@@ -57,6 +58,8 @@ module Gentle
                   xml.Notes('NoteType': note[:note_type],
                             'NoteValue': note[:note_value])
                 end
+              
+                xml.GiftWrap @gift_wrap
 
                 if @shipment.respond_to?(:value_added_services)
                   @shipment.value_added_services.each do |service|


### PR DESCRIPTION
This key is cleared for use in the quiet logistics documentation.

### Testing
- checkout https://github.com/PrimaryKids/primary/pull/5501
  -  add `,branch: "gift-wrap-update"` to line 99
  - add quiet staging testing credentials to env.dev
  - rebuild or stop and start container
- place an order in dev with the gift wrapping option checked in checkout.
- release order
- confirm that the order shows up in https://www.quietcustomer.com/QuietClientTesterPortalStage with GiftType of `wrapped`